### PR TITLE
Correct the simultaneous snapshot count.

### DIFF
--- a/copy_encrypted_ami.sh
+++ b/copy_encrypted_ami.sh
@@ -141,11 +141,11 @@ while read snapshotid; do
     echo -e "${COLOR}Copying Snapshot:${NC} ${snapshotid}"
     DST_SNAPSHOT[$i]=$(aws ec2 copy-snapshot --profile ${DST_PROFILE} --region ${DST_REGION} --source-region ${SRC_REGION} --source-snapshot-id $snapshotid --description "Copied from $snapshotid" --encrypted ${CMK_OPT} --query SnapshotId --output text|| die "Unable to copy snapshot. Aborting.")
     i=$(( $i + 1 ))
-    SIM_SNAP=$(aws ec2 describe-snapshots --profile ${DST_PROFILE} --region ${DST_REGION} --filters Name=status,Values=pending --output text | wc -l)
+    SIM_SNAP=$(aws ec2 describe-snapshots --profile "${DST_PROFILE}" --region "${DST_REGION}" --filters Name=status,Values=pending --query 'Snapshots[].SnapshotId' --output text | wc -w)
     while [ $SIM_SNAP -ge 5 ]; do
         echo -e "${COLOR}Too many concurrent Snapshots, waiting...${NC}"
         sleep 30
-        SIM_SNAP=$(aws ec2 describe-snapshots --profile ${DST_PROFILE} --region ${DST_REGION} --filters Name=status,Values=pending --output text | wc -l)
+        SIM_SNAP=$(aws ec2 describe-snapshots --profile "${DST_PROFILE}" --region "${DST_REGION}" --filters Name=status,Values=pending --query 'Snapshots[].SnapshotId' --output text | wc -w)
     done
 
 done <<< "$SNAPSHOT_IDS"


### PR DESCRIPTION
The current way simultaneous snapshots are calculated counts the lines of output from `aws ec2 describe-snapshots --filters Name=status,Values=pending` . 

However, if any of those snapshots have tags, each tag gets a line in that output like
```
TAGS	Name	mysnapshot
TAGS	sometag	some-value
```
So counting those lines over counts the actual number of snapshots. 

This has the effect of artificially capping the number of simultaneous copy operations, since 1 snapshot with 5 tags would be counted as 6 snapshots, thus blocking all other snapshots the script tries to copy.

This change just counts the snapshot ids, which should be more accurate.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
