### PR TITLE
Ensure JSON output during script operation

### DIFF
--- a/copy_encrypted_ami.sh
+++ b/copy_encrypted_ami.sh
@@ -15,6 +15,8 @@
 
 set -o errexit
 
+export AWS_DEFAULT_OUTPUT="json"
+
 usage()
 {
     echo " Usage: ${0} -s profile -d profile -a ami_id [-k key] [-l source region] [-r destination region] [-n] [-u tag:value]


### PR DESCRIPTION
This script will fail if it is called from an environment with YAML as the default output. Set the AWS_DEFAULT_OUTPUT to json for the duration of the script.

This is a one-line change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
