### PR TITLE
Add region flag to get-caller-identity calls

### DIFF
--- a/copy_encrypted_ami.sh
+++ b/copy_encrypted_ami.sh
@@ -101,9 +101,9 @@ echo -e "${COLOR}Source region:${NC}" ${SRC_REGION}
 echo -e "${COLOR}Destination region:${NC}" ${DST_REGION}
 
 # Gets the source and destination account ID
-SRC_ACCT_ID=$(aws sts get-caller-identity --profile ${SRC_PROFILE} --query Account --output text || die "Unable to get the source account ID. Aborting.")
+SRC_ACCT_ID=$(aws sts get-caller-identity --profile ${SRC_PROFILE} --region ${SRC_REGION} --query Account --output text || die "Unable to get the source account ID. Aborting.")
 echo -e "${COLOR}Source account ID:${NC}" ${SRC_ACCT_ID}
-DST_ACCT_ID=$(aws sts get-caller-identity --profile ${DST_PROFILE} --query Account --output text || die "Unable to get the destination account ID. Aborting.")
+DST_ACCT_ID=$(aws sts get-caller-identity --profile ${DST_PROFILE} --region ${DST_REGION} --query Account --output text || die "Unable to get the destination account ID. Aborting.")
 echo -e "${COLOR}Destination account ID:${NC}" ${DST_ACCT_ID}
 
 


### PR DESCRIPTION
Signed-off-by: David Schmidt <51931019+schmidtd@users.noreply.github.com>

*Description of changes:*

The first two calls to `get-caller-identity`, unlike all other subsequent `aws` calls, lack the `--region` flag.  This will fail in situations where you specify regions on the command line but don't have them defined in `~/.aws/config` file, for example.  This change adds the flags and is working successfully in an environment that had only `~/.aws/credentials` available.