### PR TITLE
Allow source to be just an account ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The source and destination profiles must be configured in the system where you a
 ```
 copy_encrypted_ami.sh -s profile -d profile -a ami_id [-k key] [-l source region] [-r destination region] [-n] [-u tag:value]
     -s,               AWS CLI profile name for AMI source account.
+    -S,               AWS source account ID (exclusive with -s, use to copy AMIs already shared).
     -d,               AWS CLI profile name for AMI destination account.
     -a,               ID of AMI to be copied.
     -N,               Name for new AMI.
@@ -42,6 +43,8 @@ By default, the currently specified region for the source and destination AWS CL
 
 Use ```aws configure --profile profile_name``` to set up your profiles (source and destination). For more information about multiple profiles, please consult https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html
 
+In cases where you need to copy an AMI that has been shared with you but you don't have credentials to the source account, use the `-S` option instead to specify the source account ID (and also specify the source region with `-l`).
+
 ## Example
 
 ```copy_encrypted_ami.sh -s mysrcprofile -d mydstprofile -a ami-61341708```
@@ -54,6 +57,12 @@ The line above copies the AMI ami-61341708 present in the account configured in 
 ```copy_encrypted_ami.sh -s mysrclocal -d mydstprofile -a ami-61341708 -k arn:aws:kms:eu-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab -l ap-southeast-2 -r eu-west-2 -n```
 
 The line above copies the AMI ami-61341708 present in the region ap-southeast-2 for the account configured in the local mysrcprofile to the account configured in the local mydstprofile in the region eu-west-2, using AWS KMS key arn:aws:kms:eu-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab in the destination and enabling ENA Support.
+
+
+
+```copy_encrypted_ami.sh -S 012345678 -d mydstprofile -a ami-61341708 -l us-east-1```
+
+The line above copies the AMI ami-61341708 present in the region us-east-1 from the AWS account ID 012345678 to the account configured in the local mydstprofile in the default region defined for mydstprofile.
 
 ## Known Limitations
 


### PR DESCRIPTION
Signed-off-by: David Schmidt <51931019+schmidtd@users.noreply.github.com>

In its current form, `copy-encrypted-ami.sh` requires you have credentialed access in both source and destination accounts.  I have a situation where I have been granted access to an AMI, and I have the account ID it's coming from... but I don't have credentials in "profile" form (i.e. I don't have key_id/access_key to the source).  As it is, we really only need the source info for a few things - pulling out KMS key(s) for one.  Most of the rest of the info can be gleaned by using the destination profile since the AMI (and snaps) have already been shared.  So if it's possible to copy a shared AMI from an account that you don't really have credentialed access to, this will do it.  Example invocation for this situation is given in the README.md.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
