### PR TITLE
Allow copy from an AMI shared from an unprivileged account

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ aws cli - https://docs.aws.amazon.com/cli/latest/userguide/installing.html
 
 
 The source and destination profiles must be configured in the system where you are running the script from.
-
+The source and destination profiles can be the same if the intent is to copy an AMI that has already been shared to the destination account, but isn't currently stored there.
 
 ## Usage
 


### PR DESCRIPTION
Signed-off-by: David Schmidt <51931019+schmidtd@users.noreply.github.com>

In its current form, copy-encrypted-ami.sh requires you have credentialed access in both source and destination accounts. I have a situation where I have been granted access to an AMI, and I have the account ID it's coming from... but I don't have credentials in "profile" form (i.e. I don't have key_id/access_key to the source).

It turns out this can be accomplished by supplying the same credentials for both source and destination accounts; the only extra step we need to take here is to not to try to add sharing attributes (since they're already set since we can see them from the destination account).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
