### PR TITLE
Add option to not encrypt snaps (despite the script name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ copy_encrypted_ami.sh -s profile -d profile -a ami_id [-k key] [-l source region
     -t,               Copy Tags. (Optional)
     -k,               Specific AWS KMS Key ID for snapshot re-encryption in target AWS account. (Optional)
     -u,               Update an existing or create a new tag with this value. Valid only with -t. (Optional)
+    -y,               Don't add encryption options to snaps. (Optional)
     -h,               Show this message.
 ```
 By default, the currently specified region for the source and destination AWS CLI profile will be used, and the default Amazon-managed AWS KMS Key for Amazon EBS.


### PR DESCRIPTION
*Description of changes:*

We have a situation where we need to copy an AMI and associated snap, but we need them unencrypted.  The shell script as is today necessarily encrypts the destination snap, and that's a problem for us.  I've added a switch (`-y` due to lack of good letters left!) to *not* encrypt the destination.  The logic is a little twisty since it's a "negative" specification, so sorry about that. :-)

Also a simple change that a shell linter suggested is included (line 43/44).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.