### PR TITLE
Remove .ImageOwnerAlias, .DeprecationTime fields from describe-images…

### DIFF
--- a/copy_encrypted_ami.sh
+++ b/copy_encrypted_ami.sh
@@ -237,7 +237,7 @@ else
 fi
 
 # Copy AMI structure while removing read-only / non-idempotent values
-NEW_AMI_DETAILS=$(echo ${AMI_DETAILS} | jq --arg NAME "${NEW_NAME}" '.Name = $NAME | del(.. | .Encrypted?) | del(.Tags,.Platform,.PlatformDetails,.UsageOperation,.ImageId,.CreationDate,.OwnerId,.ImageLocation,.State,.ImageType,.RootDeviceType,.Hypervisor,.Public,.EnaSupport,.ProductCodes,.SourceInstanceId )')
+NEW_AMI_DETAILS=$(echo ${AMI_DETAILS} | jq --arg NAME "${NEW_NAME}" '.Name = $NAME | del(.. | .Encrypted?) | del(.Tags,.Platform,.PlatformDetails,.UsageOperation,.ImageId,.CreationDate,.OwnerId,.ImageLocation,.State,.ImageType,.RootDeviceType,.Hypervisor,.Public,.EnaSupport,.ProductCodes,.SourceInstanceId,.ImageOwnerAlias,.DeprecationTime )')
 
 # Create the AMI in the destination
 CREATED_AMI=$(aws ec2 register-image --profile ${DST_PROFILE} --region ${DST_REGION} ${ENA_OPT} --cli-input-json "${NEW_AMI_DETAILS}" --query ImageId --output text || die "Unable to register AMI in the destination account. Aborting.")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove .ImageOwnerAlias, .DeprecationTime fields from describe-images response since it is not supported in register-image payload. 
Tested on aws-cli/2.15.22.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
